### PR TITLE
Fix v1.4.2.5 release package audit

### DIFF
--- a/scripts/verify-workspace.ps1
+++ b/scripts/verify-workspace.ps1
@@ -59,7 +59,15 @@ if ($buildScript.Contains($privateToolLabel, [StringComparison]::OrdinalIgnoreCa
 }
 
 & git -C $repo cat-file -e "$base^{commit}" 2>$null
-if ($LASTEXITCODE -ne 0) {
+$baseAvailable = $LASTEXITCODE -eq 0
+if (-not $baseAvailable -and $env:GITHUB_ACTIONS -eq "true") {
+    & git -C $repo fetch --no-tags --depth=1 $manifest.upstream.repository $base
+    if ($LASTEXITCODE -eq 0) {
+        & git -C $repo cat-file -e "$base^{commit}" 2>$null
+        $baseAvailable = $LASTEXITCODE -eq 0
+    }
+}
+if (-not $baseAvailable) {
     Add-Failure "Pinned upstream commit is unavailable: $base"
 }
 else {


### PR DESCRIPTION
## Cause`n`nThe clean GitHub Actions checkout does not contain the pinned upstream source commit, so the package audit fails after all builds and tests pass`n`n## Fix`n`nFetch only the manifest-pinned upstream commit when it is missing in GitHub Actions, then run the unchanged upstream diff allowlist audit`n`n## Verification`n`n- local workspace verification passed`n- the fetch is CI-only and does not change local offline verification behavior